### PR TITLE
Fixes sum_array example

### DIFF
--- a/sum_array/Makefile
+++ b/sum_array/Makefile
@@ -26,7 +26,7 @@ ifneq ($(DARWIN),)
 else
 
 # Linux OS
-LIBS=-lOpenCL
+LIBS=-lOpenCL -lm
 ifeq ($(PROC_TYPE),)
 	CFLAGS+=-m32
 else

--- a/sum_array/vecAdd.c
+++ b/sum_array/vecAdd.c
@@ -11,6 +11,21 @@
 #include <CL/cl.h>
 #endif
  
+// OpenCL kernel. Each work item takes care of one element of c
+const char *kernelSource =
+  "#pragma OPENCL EXTENSION cl_khr_fp64 : enable                    \n"
+  "__kernel void vecAdd(  __global double *a,                       \n"
+  "                       __global double *b,                       \n"
+  "                       __global double *c,                       \n"
+  "                       const unsigned int n)                    \n"
+  "{                                                               \n"
+  "    //Get our global thread ID                                  \n"
+  "    int id = get_global_id(0);                                  \n"
+  "                                                                \n"
+  "    //Make sure we do not go out of bounds                      \n"
+  "    if (id < n)                                                 \n"
+  "        c[id] = a[id] + b[id];                                  \n"
+  "}                                                               \n";
  
 int main( int argc, char* argv[] )
 {


### PR DESCRIPTION
Required the `kernelSource` string and `-lm` for the `sinf` and `cosf` functions.